### PR TITLE
Fix for inf error when no ignition found

### DIFF
--- a/pyteck/simulation.py
+++ b/pyteck/simulation.py
@@ -533,10 +533,10 @@ class Simulation(object):
             self.meta['simulated-ignition-delay'] = (ignition_delays[0] - time_comp) * units.second
         else:
             warnings.warn('No ignition for case ' + self.meta['id'] +
-                          ', setting value to 0.0 and continuing',
+                          ', setting value to nan and continuing',
                           RuntimeWarning
                           )
-            self.meta['simulated-ignition-delay'] = 0.0 * units.second
+            self.meta['simulated-ignition-delay'] = np.nan * units.second
 
         # TODO: detect two-stage ignition.
         self.meta['simulated-first-stage-delay'] = np.nan * units.second


### PR DESCRIPTION
Set simulated ignition delay to nan instead of 0.0 when no ignition is found. This was done so that the datapoint is ignored when calculating the error function for the dataset, rather than having it become inf. 