### PR TITLE
Print output to debug the TestEvalModel unit test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
 script:
   - set -e
   - if [[ -z "$TRAVIS_TAG" ]]; then
-      pytest -vv -P --cov=./;
+      pytest -vv -rP --cov=./;
       if [[ "$PYTHON" == "3.6" && "$TRAVIS_OS_NAME" == "linux" ]]; then
         git checkout -- test-environment.yaml;
         conda install -q sphinx doctr nbsphinx ipython;

--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,7 @@ install:
 script:
   - set -e
   - if [[ -z "$TRAVIS_TAG" ]]; then
-      pytest -vv --cov=./;
+      pytest -vv -P --cov=./;
       if [[ "$PYTHON" == "3.6" && "$TRAVIS_OS_NAME" == "linux" ]]; then
         git checkout -- test-environment.yaml;
         conda install -q sphinx doctr nbsphinx ipython;

--- a/pyteck/tests/test_eval_model.py
+++ b/pyteck/tests/test_eval_model.py
@@ -219,6 +219,7 @@ class TestEvalModel:
                 num_threads=1,
                 skip_validation=True
                 )
+            print(output)
             assert numpy.isclose(output['average error function'], 58.78211242028232, rtol=1.e-3)
             assert numpy.isclose(output['error function standard deviation'], 0.0, rtol=1.e-3)
             assert numpy.isclose(output['average deviation function'], 7.635983785416241, rtol=1.e-3)


### PR DESCRIPTION
This unit test is failing on Travis only on Python 3.6 but not Python 3.5 on PR #20,
and we can't make sense of why. This is mostly a "no change" pull request to trigger 
the CI tests, but I added a print(output) statement to help debug.