### PR TITLE
Pyteck Bug Fixes 

### DIFF
--- a/pyteck/simulation.py
+++ b/pyteck/simulation.py
@@ -410,10 +410,13 @@ class Simulation(object):
             ind = None
             for sp in try_list:
                 try:
-                    ind = self.gas.species_index(sp)
+                    ind = self.gas.species_index(species_key[sp])
                     break
                 except ValueError:
                     pass
+                except KeyError:
+                    pass
+
 
             # store index of target species
             if ind:

--- a/pyteck/simulation.py
+++ b/pyteck/simulation.py
@@ -533,7 +533,7 @@ class Simulation(object):
                                                  self.properties.ignition_target,
                                                  self.properties.ignition_type
                                                  )
-            self.meta['simulated-ignition-delay'] = (ignition_delays[0] - time_comp) * units.second
+            self.meta['simulated-ignition-delay'] = (ignition_delays[-1] - time_comp) * units.second
         else:
             warnings.warn('No ignition for case ' + self.meta['id'] +
                           ', setting value to 0.0 and continuing',


### PR DESCRIPTION
1. When looking for the 'target species' for ignition detection, the species key is now used to translate between the name of the species requested by the experimental data and the name used in the model. This is to resolve an issue where pyteck could not find the requested species and was falling back to pressure. 

2. Instead of using the first time in the list of ignition delays returned from get_ignition_delay, the last time is now used since this seems to be the 'max' peak for each of the ignition types based on the way that the ignition delays list is populated. This is to resolve an issue where pyteck was always taking the earliest peak rather than the max peak for specific ignition types. 